### PR TITLE
Remove `burgh` alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,10 @@ build:
 install: build
 	mkdir -p $(bindir)
 	install .build/release/badonde $(bindir)
-	install .build/release/burgh $(bindir)
 
 test:
 	swift test
 
 uninstall:
 	rm -rf $(bindir)/badonde
-	rm -rf $(bindir)/burgh
 	rm -rf ~/.badonde

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,6 @@ let package = Package(
 	],
 	products: [
 		.executable(name: "badonde", targets: ["Badonde"]),
-		.executable(name: "burgh", targets: ["Burgh"])
 	],
 	dependencies: [
 		.package(
@@ -42,10 +41,6 @@ let package = Package(
 				"Jira",
 				"Sugar"
 			]
-		),
-		.target(
-			name: "Burgh",
-			dependencies: ["BadondeCore"]
 		),
 		.target(
 			name: "Git",

--- a/Sources/Burgh/main.swift
+++ b/Sources/Burgh/main.swift
@@ -1,4 +1,0 @@
-import Foundation
-import BadondeCore
-
-CommandLineTool().run(with: ["burgh"] + CommandLine.arguments.dropFirst())


### PR DESCRIPTION
Given the `appify` command being available to make Badonde very easily actionable, it doesn't make sense to keep the `burgh` pseudo-alias at the core of this tool.

## Benefits

- Faster installation & binary sizes.
- One less target to maintain.
- Less confusion for new adopters about what is what.

A very easy way to counter this removal is to create a local bash alias.