### PR TITLE
Fix Logger steps glitching

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/DavdRoman/CLISpinner",
         "state": {
           "branch": "master",
-          "revision": "b15eacb7dfac0e6305f106795177a363552ee940",
+          "revision": "1bf800a3be033882effcb879a4791b105a54c474",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/DavdRoman/CLISpinner",
         "state": {
           "branch": "master",
-          "revision": "1bf800a3be033882effcb879a4791b105a54c474",
+          "revision": "773e04c9c1df4bf2d9a52a6a0d3511d11a1a8f59",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/DavdRoman/SwiftCLI",
         "state": {
           "branch": "master",
-          "revision": "ff0fc25a50e03276a559b5722e98bc7674d2f0db",
+          "revision": "289415ead7e2210347c0bbbc4a77f067262117bc",
           "version": null
         }
       },

--- a/Sources/BadondeCore/AppifyCommand.swift
+++ b/Sources/BadondeCore/AppifyCommand.swift
@@ -10,8 +10,6 @@ class AppifyCommand: Command {
 	let shortDescription = "Generates a Badonde.app for your specific project"
 
 	func execute() throws {
-		defer { Logger.fail() } // defers failure call if `Logger.finish()` isn't called at the end, which means an error was thrown along the way
-
 		Logger.step("Reading configuration")
 		let projectPath = try Repository().topLevelPath
 		let configuration = try DynamicConfiguration(prioritizedScopes: [.local(projectPath), .global])
@@ -84,7 +82,5 @@ class AppifyCommand: Command {
 		Logger.info("Shortcut was set up but you might need to close currently active applications for it to work")
 
 		_ = try capture(bash: "open -R \(appPath)")
-
-		Logger.succeed()
 	}
 }

--- a/Sources/BadondeCore/AppifyCommand.swift
+++ b/Sources/BadondeCore/AppifyCommand.swift
@@ -65,7 +65,6 @@ class AppifyCommand: Command {
 		do {
 			_ = try capture(bash: "open '/System/Library/CoreServices/Script Menu.app'")
 		} catch {
-			Logger.succeed()
 			Logger.info("App was added to the Script Menu, to show go to Script Editor.app -> Preferences -> Show Script menu in menu bar")
 		}
 
@@ -82,11 +81,10 @@ class AppifyCommand: Command {
 		let service = Service(bundleIdentifier: nil, menuItemName: serviceName, message: "runWorkflowAsService")
 		try Service.KeyEquivalentConfigurator().addKeyEquivalent("@~^b", for: service)
 		_ = try capture(bash: "defaults read pbs")
-		Logger.succeed()
 		Logger.info("Shortcut was set up but you might need to close currently active applications for it to work")
 
 		_ = try capture(bash: "open -R \(appPath)")
 
-		Logger.finish()
+		Logger.succeed()
 	}
 }

--- a/Sources/BadondeCore/BurghCommand.swift
+++ b/Sources/BadondeCore/BurghCommand.swift
@@ -23,8 +23,6 @@ class BurghCommand: Command {
 	}
 
 	func execute() throws {
-		defer { Logger.fail() } // defers failure call if `Logger.finish()` isn't called at the end, which means an error was thrown along the way
-
 		Logger.step("Reading configuration")
 		let projectPath = try Repository().topLevelPath
 		let configuration = try DynamicConfiguration(prioritizedScopes: [.local(projectPath), .global])
@@ -190,7 +188,5 @@ class BurghCommand: Command {
 			try reporter.report(pullRequest.analyticsData(startDate: startDate))
 		}
 		#endif
-
-		Logger.succeed()
 	}
 }

--- a/Sources/BadondeCore/BurghCommand.swift
+++ b/Sources/BadondeCore/BurghCommand.swift
@@ -63,7 +63,6 @@ class BurghCommand: Command {
 				Logger.step("Local branch is ahead of remote, pushing changes now")
 				try Git.Push.perform(remote: remote, branch: currentBranch)
 			} else {
-				Logger.succeed()
 				Logger.info("Local branch is ahead of remote, please push your changes")
 			}
 		}
@@ -192,6 +191,6 @@ class BurghCommand: Command {
 		}
 		#endif
 
-		Logger.finish()
+		Logger.succeed()
 	}
 }

--- a/Sources/BadondeCore/ClearCommand.swift
+++ b/Sources/BadondeCore/ClearCommand.swift
@@ -26,8 +26,6 @@ class ClearCommand: Command {
 	}()
 
 	func execute() throws {
-		defer { Logger.fail() } // defers failure call if `Logger.finish()` isn't called at the end, which means an error was thrown along the way
-
 		Logger.warn(deprecationNotice + "\n")
 
 		Logger.step("Removing existing configuration")
@@ -36,7 +34,5 @@ class ClearCommand: Command {
 		try configuration.removeValue(forKeyPath: .jiraEmail)
 		try configuration.removeValue(forKeyPath: .jiraApiToken)
 		try configuration.removeValue(forKeyPath: .githubAccessToken)
-
-		Logger.succeed()
 	}
 }

--- a/Sources/BadondeCore/ClearCommand.swift
+++ b/Sources/BadondeCore/ClearCommand.swift
@@ -37,6 +37,6 @@ class ClearCommand: Command {
 		try configuration.removeValue(forKeyPath: .jiraApiToken)
 		try configuration.removeValue(forKeyPath: .githubAccessToken)
 
-		Logger.finish()
+		Logger.succeed()
 	}
 }

--- a/Sources/BadondeCore/CommandLineTool.swift
+++ b/Sources/BadondeCore/CommandLineTool.swift
@@ -74,7 +74,7 @@ public final class CommandLineTool {
 		let reporter = ErrorAnalyticsReporter(firebaseProjectId: firebaseProjectId, firebaseSecretToken: firebaseSecretToken)
 		try reporter.report(error.analyticsData())
 
-		Logger.finish()
+		Logger.succeed()
 	}
 
 	private func logElapsedTime(withStartDate startDate: Date) {

--- a/Sources/BadondeCore/ConfigCommand.swift
+++ b/Sources/BadondeCore/ConfigCommand.swift
@@ -80,7 +80,6 @@ class ConfigCommand: Command {
 			}
 			try configuration.setRawValue(value, forKeyPath: keyPath)
 			if !keyPathIsSupported {
-				Logger.succeed()
 				Logger.info("Value '\(value)' was set for '\(keyPath.rawValue)', however this key is not used by Badonde")
 			}
 		case (false, false, true): // unset
@@ -91,7 +90,6 @@ class ConfigCommand: Command {
 				Logger.step("Setting...")
 				try configuration.setRawValue(value, forKeyPath: keyPath)
 				if !keyPathIsSupported {
-					Logger.succeed()
 					Logger.info("Value '\(value)' was set for '\(keyPath.rawValue)', however this key is not used by Badonde")
 				}
 			} else if let value = try configuration.getRawValue(forKeyPath: keyPath) {
@@ -101,7 +99,7 @@ class ConfigCommand: Command {
 			fatalError("More than one config action option was specified")
 		}
 
-		Logger.finish()
+		Logger.succeed()
 	}
 
 	private func configuration(forLocalValue localValue: Bool, globalValue: Bool) throws -> KeyValueInteractive {

--- a/Sources/BadondeCore/ConfigCommand.swift
+++ b/Sources/BadondeCore/ConfigCommand.swift
@@ -59,8 +59,6 @@ class ConfigCommand: Command {
 	let value = OptionalParameter(completion: .none)
 
 	func execute() throws {
-		defer { Logger.fail() } // defers failure call if `Logger.finish()` isn't called at the end, which means an error was thrown along the way
-
 		guard let keyPath = KeyPath(rawValue: key.value) else {
 			throw Error.incompatibleKey(key.value)
 		}
@@ -98,8 +96,6 @@ class ConfigCommand: Command {
 		default:
 			fatalError("More than one config action option was specified")
 		}
-
-		Logger.succeed()
 	}
 
 	private func configuration(forLocalValue localValue: Bool, globalValue: Bool) throws -> KeyValueInteractive {

--- a/Sources/BadondeCore/ConfigurationStore.swift
+++ b/Sources/BadondeCore/ConfigurationStore.swift
@@ -46,8 +46,6 @@ final class LegacyConfigurationStore {
 	}
 
 	class func migrateIfNeeded() throws {
-		defer { Logger.fail() } // defers failure call if `Logger.finish()` isn't called at the end, which means an error was thrown along the way
-
 		// Append .badonde to .gitignore if not present.
 		// Remove along with whole class when `badonde init` is implemented.
 		// https://github.com/davdroman/Badonde/pull/79
@@ -85,8 +83,6 @@ final class LegacyConfigurationStore {
 		}
 
 		try FileManager.default.removeItem(at: LegacyConfigurationStore.folderPath)
-
-		Logger.succeed()
 	}
 
 	private func createConfigurationFolderIfNeeded() throws {

--- a/Sources/BadondeCore/ConfigurationStore.swift
+++ b/Sources/BadondeCore/ConfigurationStore.swift
@@ -86,7 +86,7 @@ final class LegacyConfigurationStore {
 
 		try FileManager.default.removeItem(at: LegacyConfigurationStore.folderPath)
 
-		Logger.finish()
+		Logger.succeed()
 	}
 
 	private func createConfigurationFolderIfNeeded() throws {

--- a/Sources/BadondeCore/Logger.swift
+++ b/Sources/BadondeCore/Logger.swift
@@ -2,36 +2,46 @@ import Foundation
 import CLISpinner
 
 public final class Logger {
-	private static var spinner: Spinner?
+	private static let spinner = Spinner(pattern: .dots, color: .lightCyan, shouldHideCursor: false)
+	private static var isStepping = false
 
 	public class func step(_ description: String) {
-		spinner?.succeed()
-		spinner = Spinner(pattern: .dots, text: description, color: .lightCyan, shouldHideCursor: false)
-		spinner?.start()
+		if isStepping {
+			spinner.succeed()
+		}
+		spinner.pattern = Pattern(from: Pattern.dots.symbols.map { $0.applyingColor(.lightCyan) })
+		spinner.text = description
+		spinner.start()
+		isStepping = true
 	}
 
-	public class func info(_ description: String) {
-		spinner?.info(text: description)
-		spinner = nil
+	public class func info(_ description: String, succeedPrevious: Bool = true) {
+		if isStepping, succeedPrevious {
+			spinner.succeed()
+			isStepping = false
+		}
+		spinner.info(text: description)
 	}
 
-	public class func warn(_ description: String) {
-		spinner = Spinner(pattern: .dots, text: description, color: .lightCyan, shouldHideCursor: false)
-		spinner?.warn(text: description)
-		spinner = nil
+	public class func warn(_ description: String, succeedPrevious: Bool = true) {
+		if isStepping, succeedPrevious {
+			spinner.succeed()
+			isStepping = false
+		}
+		spinner.warn(text: description)
 	}
 
 	public class func fail() {
-		spinner?.fail()
-		spinner = nil
+		if isStepping {
+			spinner.fail()
+			isStepping = false
+		}
 	}
 
 	public class func succeed() {
-		spinner?.succeed()
-	}
-
-	public class func finish() {
-		spinner?.succeed()
-		spinner = nil
+		if isStepping {
+			spinner.succeed()
+			isStepping = false
+		}
 	}
 }

--- a/Sources/BadondeCore/Logger.swift
+++ b/Sources/BadondeCore/Logger.swift
@@ -2,7 +2,7 @@ import Foundation
 import CLISpinner
 
 public final class Logger {
-	private static let spinner = Spinner(pattern: .dots, color: .lightCyan, shouldHideCursor: false)
+	private static let spinner = Spinner(pattern: .dots, color: .lightCyan)
 	private static var isStepping = false
 
 	public class func step(_ description: String) {
@@ -18,17 +18,17 @@ public final class Logger {
 	public class func info(_ description: String, succeedPrevious: Bool = true) {
 		if isStepping, succeedPrevious {
 			spinner.succeed()
-			isStepping = false
 		}
 		spinner.info(text: description)
+		isStepping = false
 	}
 
 	public class func warn(_ description: String, succeedPrevious: Bool = true) {
 		if isStepping, succeedPrevious {
 			spinner.succeed()
-			isStepping = false
 		}
 		spinner.warn(text: description)
+		isStepping = false
 	}
 
 	public class func fail() {
@@ -43,5 +43,9 @@ public final class Logger {
 			spinner.succeed()
 			isStepping = false
 		}
+	}
+
+	public class func finish() {
+		spinner.unhideCursor()
 	}
 }

--- a/Sources/BadondeCore/Logger.swift
+++ b/Sources/BadondeCore/Logger.swift
@@ -8,9 +8,11 @@ public final class Logger {
 	public class func step(_ description: String) {
 		if isStepping {
 			spinner.succeed()
+			spinner.text = description
+		} else {
+			spinner._text = description
 		}
 		spinner.pattern = Pattern(from: Pattern.dots.symbols.map { $0.applyingColor(.lightCyan) })
-		spinner.text = description
 		spinner.start()
 		isStepping = true
 	}

--- a/Sources/BadondeCore/SetFirebaseAuthCommand.swift
+++ b/Sources/BadondeCore/SetFirebaseAuthCommand.swift
@@ -37,6 +37,6 @@ class SetFirebaseAuthCommand: Command {
 		try configuration.setValue(projectId.value, forKeyPath: .firebaseProjectId)
 		try configuration.setValue(secretToken.value, forKeyPath: .firebaseSecretToken)
 
-		Logger.finish()
+		Logger.succeed()
 	}
 }

--- a/Sources/BadondeCore/SetFirebaseAuthCommand.swift
+++ b/Sources/BadondeCore/SetFirebaseAuthCommand.swift
@@ -27,8 +27,6 @@ class SetFirebaseAuthCommand: Command {
 	let secretToken = Parameter()
 
 	func execute() throws {
-		defer { Logger.fail() } // defers failure call if `Logger.finish()` isn't called at the end, which means an error was thrown along the way
-
 		Logger.warn(deprecationNotice + "\n")
 
 		Logger.step("Setting Firebase configuration")
@@ -36,7 +34,5 @@ class SetFirebaseAuthCommand: Command {
 		let configuration = try Configuration(scope: .local(projectPath))
 		try configuration.setValue(projectId.value, forKeyPath: .firebaseProjectId)
 		try configuration.setValue(secretToken.value, forKeyPath: .firebaseSecretToken)
-
-		Logger.succeed()
 	}
 }

--- a/Sources/BadondeCore/Sugar/Command+Sugar.swift
+++ b/Sources/BadondeCore/Sugar/Command+Sugar.swift
@@ -27,7 +27,7 @@ extension Command {
 			return value
 		}
 
-		Logger.info("Credentials required")
+		Logger.info("Credentials required", succeedPrevious: false)
 
 		switch keyPath {
 		case .jiraEmail:

--- a/Sources/BadondeCore/Sugar/Command+Sugar.swift
+++ b/Sources/BadondeCore/Sugar/Command+Sugar.swift
@@ -45,7 +45,7 @@ extension Command {
 			openURL(.jiraApiTokenUrl, delay: CommandConstant.urlOpeningDelay)
 			#endif
 			let jiraApiTokenInput = Input.readLine(
-				prompt: "Enter JIRA API token (generated at '\(URL.jiraApiTokenUrl)':",
+				prompt: "Enter JIRA API token (generated at '\(URL.jiraApiTokenUrl)'):",
 				secure: true,
 				errorResponse: { input, invalidInputReason in
 					self.stderr <<< "Invalid token; \(invalidInputReason)"
@@ -58,7 +58,7 @@ extension Command {
 			openURL(.githubApiTokenUrl, delay: CommandConstant.urlOpeningDelay)
 			#endif
 			let githubAccessTokenInput = Input.readLine(
-				prompt: "Enter GitHub API token with 'repo' scope (generated at '\(URL.githubApiTokenUrl)':",
+				prompt: "Enter GitHub API token with 'repo' scope (generated at '\(URL.githubApiTokenUrl)'):",
 				secure: true,
 				errorResponse: { input, invalidInputReason in
 					self.stderr <<< "Invalid token; \(invalidInputReason)"


### PR DESCRIPTION
## Implementation

Remove the optional instance of `Spinner` and replace for a unique singleton that respects the execution queue. To keep previous behavior consistent, add a flag to tell whether a step is currently happening and respond appropriately to stopping events by checking said flag first. Finally, make the interface's behavior clear about the succession of steps by succeeding the previous step always by default except if the user specifies `false` for a `succeedPrevious` flag defaulted to `true`.