### PR TITLE
Fix version of Danger to 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     packages:
       - swiftlint
 install:
-  - npm install -g danger
+  - npm install -g danger@7.x
   - swift build
 script:
   - swift run danger-swift ci


### PR DESCRIPTION
Description for Danger to pass while https://github.com/danger/swift/issues/236 is a thing.