### PR TITLE
Edit command

### DIFF
--- a/Sources/CLI/CommandLineTool.swift
+++ b/Sources/CLI/CommandLineTool.swift
@@ -26,9 +26,10 @@ public final class CommandLineTool {
 			version: Constant.version,
 			description: Constant.description,
 			commands: [
-				InitCommand(startDatePointer: startDatePointer),
 				AppifyCommand(),
 				ConfigCommand(),
+				EditCommand(startDatePointer: startDatePointer),
+				InitCommand(startDatePointer: startDatePointer),
 				PRCommand(startDatePointer: startDatePointer),
 			]
 		)

--- a/Sources/CLI/EditCommand.swift
+++ b/Sources/CLI/EditCommand.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftCLI
+import Core
 import Git
 
 final class EditCommand: Command {
@@ -22,7 +23,7 @@ final class EditCommand: Command {
 
 	func execute() throws {
 		let repositoryPath = try Repository(atPath: FileManager.default.currentDirectoryPath).topLevelPath
-		try EditingCoordinator().editBadondefileAndWait(forRepositoryPath: repositoryPath)
+		try Badondefile.EditingCoordinator().editBadondefile(forRepositoryPath: repositoryPath)
 
 		// Reset start date because editing take an indefinite amount of time
 		// and this time is irrelevant to tool performance.

--- a/Sources/CLI/EditCommand.swift
+++ b/Sources/CLI/EditCommand.swift
@@ -21,6 +21,9 @@ final class EditCommand: Command {
 	}
 
 	func execute() throws {
+		let repositoryPath = try Repository(atPath: FileManager.default.currentDirectoryPath).topLevelPath
+		try EditingCoordinator().editBadondefileAndWait(forRepositoryPath: repositoryPath)
+
 		// Reset start date because editing take an indefinite amount of time
 		// and this time is irrelevant to tool performance.
 		startDatePointer.pointee = Date()

--- a/Sources/CLI/EditCommand.swift
+++ b/Sources/CLI/EditCommand.swift
@@ -1,0 +1,28 @@
+import Foundation
+import SwiftCLI
+import Git
+
+final class EditCommand: Command {
+	let name = "edit"
+	let shortDescription = "Opens Badondefile.swift on Xcode"
+	let longDescription =
+		"""
+		Opens Badondefile.swift on Xcode.
+
+		This command helps editing your current Badondefile.swift
+		by setting up an temporary Xcode project for it enabling
+		full autocompletion support.
+		"""
+
+	let startDatePointer: UnsafeMutablePointer<Date>
+
+	init(startDatePointer: UnsafeMutablePointer<Date>) {
+		self.startDatePointer = startDatePointer
+	}
+
+	func execute() throws {
+		// Reset start date because editing take an indefinite amount of time
+		// and this time is irrelevant to tool performance.
+		startDatePointer.pointee = Date()
+	}
+}

--- a/Sources/CLI/EditingCoordinator.swift
+++ b/Sources/CLI/EditingCoordinator.swift
@@ -3,63 +3,65 @@ import SwiftCLI
 import Core
 import Sugar
 
-final class EditingCoordinator {
-	init() { }
+extension Badondefile {
+	final class EditingCoordinator {
+		init() { }
 
-	func editBadondefileAndWait(forRepositoryPath path: String) throws {
-		let badondefilePath = try Badondefile.path(forRepositoryPath: path)
-		let fileManager = FileManager.default
+		func editBadondefile(forRepositoryPath path: String) throws {
+			let badondefilePath = try Badondefile.path(forRepositoryPath: path)
+			let fileManager = FileManager.default
 
-		Logger.step("Generating Xcode project for Badondefile")
+			Logger.step("Generating Xcode project for Badondefile")
 
-		let badondefileProjectURL = fileManager.temporaryDirectory.appendingPathComponent("Badondefile-\(path.sha1())")
-		if !fileManager.fileExists(atPath: badondefileProjectURL.path) {
-			try fileManager.createDirectory(atPath: badondefileProjectURL.path, withIntermediateDirectories: false, attributes: nil)
+			let badondefileProjectURL = fileManager.temporaryDirectory.appendingPathComponent("Badondefile-\(path.sha1())")
+			if !fileManager.fileExists(atPath: badondefileProjectURL.path) {
+				try fileManager.createDirectory(atPath: badondefileProjectURL.path, withIntermediateDirectories: false, attributes: nil)
+			}
+
+			let packageFilePath = badondefileProjectURL.appendingPathComponent("Package.swift").path
+			let packageFileContents = """
+			// swift-tools-version:5.0
+			// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+			import PackageDescription
+
+			let package = Package(
+				name: "Badondefile",
+				platforms: [.macOS(.v10_13)],
+				products: [.library(name: "BadondefileProduct", targets: ["Badondefile"])],
+				dependencies: [],
+				targets: [.target(name: "Badondefile", dependencies: [])]
+			)
+			"""
+			try fileManager.createFile(atPath: packageFilePath, withIntermediateDirectories: false, contents: Data(packageFileContents.utf8))
+
+			let sourceURL = badondefileProjectURL.appendingPathComponent("Sources/Badondefile")
+			let mainFilePath = sourceURL.appendingPathComponent("main.swift").path
+			if !fileManager.fileExists(atPath: sourceURL.path) {
+				try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true, attributes: nil)
+			}
+			try Data(contentsOf: URL(fileURLWithPath: badondefilePath)).write(to: URL(fileURLWithPath: mainFilePath))
+
+			let xcconfigPath = badondefileProjectURL.appendingPathComponent("config.xcconfig").path
+			let librariesPath = Badondefile.librariesPath(forRepositoryPath: path)
+			let xcconfigContents = """
+			LIBRARY_SEARCH_PATHS = \(librariesPath)
+			OTHER_SWIFT_FLAGS = -DXcode -I \(librariesPath) -L \(librariesPath)
+			OTHER_LDFLAGS = -l BadondeKit
+			"""
+			try fileManager.createFile(atPath: xcconfigPath, withIntermediateDirectories: false, contents: Data(xcconfigContents.utf8))
+
+			_ = try capture(bash: "(cd \(badondefileProjectURL.path) && swift package generate-xcodeproj --xcconfig-overrides config.xcconfig)")
+
+			let xcodeProjectPath = badondefileProjectURL.appendingPathComponent("Badondefile.xcodeproj").path
+			_ = try capture(bash: "open '\(xcodeProjectPath)'")
+
+			Logger.info("Badonde will keep running, in order to save any changes you make in Xcode back to the original Badondefile")
+			Logger.info("Press the RETURN key once you're done editing")
+			_ = readLine() // waits for ENTER keystroke to save file back
+
+			Logger.step("Saving Badondefile.swift")
+			try Data(contentsOf: URL(fileURLWithPath: mainFilePath)).write(to: URL(fileURLWithPath: badondefilePath))
 		}
-
-		let packageFilePath = badondefileProjectURL.appendingPathComponent("Package.swift").path
-		let packageFileContents = """
-		// swift-tools-version:5.0
-		// The swift-tools-version declares the minimum version of Swift required to build this package.
-
-		import PackageDescription
-
-		let package = Package(
-			name: "Badondefile",
-			platforms: [.macOS(.v10_13)],
-			products: [.library(name: "BadondefileProduct", targets: ["Badondefile"])],
-			dependencies: [],
-			targets: [.target(name: "Badondefile", dependencies: [])]
-		)
-		"""
-		try fileManager.createFile(atPath: packageFilePath, withIntermediateDirectories: false, contents: Data(packageFileContents.utf8))
-
-		let sourceURL = badondefileProjectURL.appendingPathComponent("Sources/Badondefile")
-		let mainFilePath = sourceURL.appendingPathComponent("main.swift").path
-		if !fileManager.fileExists(atPath: sourceURL.path) {
-			try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true, attributes: nil)
-		}
-		try Data(contentsOf: URL(fileURLWithPath: badondefilePath)).write(to: URL(fileURLWithPath: mainFilePath))
-
-		let xcconfigPath = badondefileProjectURL.appendingPathComponent("config.xcconfig").path
-		let librariesPath = Badondefile.librariesPath(forRepositoryPath: path)
-		let xcconfigContents = """
-		LIBRARY_SEARCH_PATHS = \(librariesPath)
-		OTHER_SWIFT_FLAGS = -DXcode -I \(librariesPath) -L \(librariesPath)
-		OTHER_LDFLAGS = -l BadondeKit
-		"""
-		try fileManager.createFile(atPath: xcconfigPath, withIntermediateDirectories: false, contents: Data(xcconfigContents.utf8))
-
-		_ = try capture(bash: "(cd \(badondefileProjectURL.path) && swift package generate-xcodeproj --xcconfig-overrides config.xcconfig)")
-
-		let xcodeProjectPath = badondefileProjectURL.appendingPathComponent("Badondefile.xcodeproj").path
-		_ = try capture(bash: "open '\(xcodeProjectPath)'")
-
-		Logger.info("Badonde will keep running, in order to save any changes you make in Xcode back to the original Badondefile")
-		Logger.info("Press the RETURN key once you're done editing")
-		_ = readLine() // waits for ENTER keystroke to save file back
-
-		Logger.step("Saving Badondefile.swift")
-		try Data(contentsOf: URL(fileURLWithPath: mainFilePath)).write(to: URL(fileURLWithPath: badondefilePath))
 	}
 }

--- a/Sources/CLI/EditingCoordinator.swift
+++ b/Sources/CLI/EditingCoordinator.swift
@@ -1,0 +1,65 @@
+import Foundation
+import SwiftCLI
+import Core
+import Sugar
+
+final class EditingCoordinator {
+	init() { }
+
+	func editBadondefileAndWait(forRepositoryPath path: String) throws {
+		let badondefilePath = try Badondefile.path(forRepositoryPath: path)
+		let fileManager = FileManager.default
+
+		Logger.step("Generating Xcode project for Badondefile")
+
+		let badondefileProjectURL = fileManager.temporaryDirectory.appendingPathComponent("Badondefile-\(path.sha1())")
+		if !fileManager.fileExists(atPath: badondefileProjectURL.path) {
+			try fileManager.createDirectory(atPath: badondefileProjectURL.path, withIntermediateDirectories: false, attributes: nil)
+		}
+
+		let packageFilePath = badondefileProjectURL.appendingPathComponent("Package.swift").path
+		let packageFileContents = """
+		// swift-tools-version:5.0
+		// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+		import PackageDescription
+
+		let package = Package(
+			name: "Badondefile",
+			platforms: [.macOS(.v10_13)],
+			products: [.library(name: "BadondefileProduct", targets: ["Badondefile"])],
+			dependencies: [],
+			targets: [.target(name: "Badondefile", dependencies: [])]
+		)
+		"""
+		try fileManager.createFile(atPath: packageFilePath, withIntermediateDirectories: false, contents: Data(packageFileContents.utf8))
+
+		let sourceURL = badondefileProjectURL.appendingPathComponent("Sources/Badondefile")
+		let mainFilePath = sourceURL.appendingPathComponent("main.swift").path
+		if !fileManager.fileExists(atPath: sourceURL.path) {
+			try fileManager.createDirectory(at: sourceURL, withIntermediateDirectories: true, attributes: nil)
+		}
+		try Data(contentsOf: URL(fileURLWithPath: badondefilePath)).write(to: URL(fileURLWithPath: mainFilePath))
+
+		let xcconfigPath = badondefileProjectURL.appendingPathComponent("config.xcconfig").path
+		let librariesPath = Badondefile.librariesPath(forRepositoryPath: path)
+		let xcconfigContents = """
+		LIBRARY_SEARCH_PATHS = \(librariesPath)
+		OTHER_SWIFT_FLAGS = -DXcode -I \(librariesPath) -L \(librariesPath)
+		OTHER_LDFLAGS = -l BadondeKit
+		"""
+		try fileManager.createFile(atPath: xcconfigPath, withIntermediateDirectories: false, contents: Data(xcconfigContents.utf8))
+
+		_ = try capture(bash: "(cd \(badondefileProjectURL.path) && swift package generate-xcodeproj --xcconfig-overrides config.xcconfig)")
+
+		let xcodeProjectPath = badondefileProjectURL.appendingPathComponent("Badondefile.xcodeproj").path
+		_ = try capture(bash: "open '\(xcodeProjectPath)'")
+
+		Logger.info("Badonde will keep running, in order to save any changes you make in Xcode back to the original Badondefile")
+		Logger.info("Press the RETURN key once you're done editing")
+		_ = readLine() // waits for ENTER keystroke to save file back
+
+		Logger.step("Saving Badondefile.swift")
+		try Data(contentsOf: URL(fileURLWithPath: mainFilePath)).write(to: URL(fileURLWithPath: badondefilePath))
+	}
+}

--- a/Sources/CLI/Initializer.swift
+++ b/Sources/CLI/Initializer.swift
@@ -80,7 +80,7 @@ final class Initializer {
 	}
 
 	private func createBadondefile(forRepositoryPath path: String) throws {
-		if (try? BadondefileRunner(forRepositoryPath: path).badondefilePath()) != nil {
+		if (try? Badondefile.path(forRepositoryPath: path)) != nil {
 			return
 		}
 

--- a/Sources/CLI/PRCommand.swift
+++ b/Sources/CLI/PRCommand.swift
@@ -40,9 +40,8 @@ final class PRCommand: Command {
 
 		try autopushIfNeeded(to: remote, configuration: configuration)
 
-		// Reset start date because credentials might've been prompted
-		// or autopush might've been performed and analytics data about
-		// tool performance might be skewed as a result.
+		// Reset start date because autopush might've been performed
+		// and analytics data about tool performance might be skewed as a result.
 		startDatePointer.pointee = Date()
 
 		Logger.step("Evaluating Badondefile.swift")

--- a/Sources/CLI/PRCommand.swift
+++ b/Sources/CLI/PRCommand.swift
@@ -45,7 +45,7 @@ final class PRCommand: Command {
 		startDatePointer.pointee = Date()
 
 		Logger.step("Evaluating Badondefile.swift")
-		let badondefileOutput = try BadondefileRunner(forRepositoryPath: repository.topLevelPath).run(
+		let badondefileOutput = try Badondefile.Runner(forRepositoryPath: repository.topLevelPath).run(
 			with: Payload(
 				git: .init(
 					path: projectPath,

--- a/Sources/Core/BadondefileRunner.swift
+++ b/Sources/Core/BadondefileRunner.swift
@@ -100,7 +100,7 @@ extension Badondefile {
 		}
 
 		private lazy var bashLibrariesPath: String = {
-			return "'\(Badondefile.librariesPath(forRepositoryPath: self.repositoryPath))'"
+			"'\(Badondefile.librariesPath(forRepositoryPath: self.repositoryPath))'"
 		}()
 
 		private func bashBadondefilePath() throws -> String {

--- a/Sources/Core/BadondefileRunner.swift
+++ b/Sources/Core/BadondefileRunner.swift
@@ -15,6 +15,16 @@ public enum Badondefile {
 		}
 		return path
 	}
+
+	public static func librariesPath(forRepositoryPath path: String) -> String {
+		let path: String
+		#if DEBUG
+		path = URL(fileURLWithPath: CommandLine.arguments[0]).deletingLastPathComponent().path
+		#else
+		path = "/usr/local/lib/badonde"
+		#endif
+		return path
+	}
 }
 
 extension Badondefile {
@@ -90,13 +100,7 @@ extension Badondefile {
 		}
 
 		private lazy var bashLibrariesPath: String = {
-			let path: String
-			#if DEBUG
-			path = URL(fileURLWithPath: CommandLine.arguments[0]).deletingLastPathComponent().path
-			#else
-			path = "/usr/local/lib/badonde"
-			#endif
-			return "'\(path)'"
+			return "'\(Badondefile.librariesPath(forRepositoryPath: self.repositoryPath))'"
 		}()
 
 		private func bashBadondefilePath() throws -> String {

--- a/Sources/Core/BadondefileRunner.swift
+++ b/Sources/Core/BadondefileRunner.swift
@@ -117,7 +117,10 @@ extension Badondefile {
 		public var errorDescription: String? {
 			switch self {
 			case .badondefileNotFound:
-				return "Could not find Badondefile.swift within current repository"
+				return [
+					"Could not find Badondefile.swift within current repository",
+					"Please run 'badonde init'"
+				].joined(separator: "\n")
 			}
 		}
 	}

--- a/Sources/Core/BadondefileRunner.swift
+++ b/Sources/Core/BadondefileRunner.swift
@@ -4,15 +4,9 @@ import struct BadondeKit.Payload
 import enum BadondeKit.Log
 import struct BadondeKit.Output
 
-public final class BadondefileRunner {
-	let repositoryPath: String
-
-	public init(forRepositoryPath path: String) {
-		self.repositoryPath = path
-	}
-
-	public func badondefilePath() throws -> String {
-		let bash = "find '\(repositoryPath)' -type f -iname 'Badondefile.swift' ! -path .git"
+public enum Badondefile {
+	public static func path(forRepositoryPath path: String) throws -> String {
+		let bash = "find '\(path)' -type f -iname 'Badondefile.swift' ! -path .git"
 		guard
 			let path = try capture(bash: bash).stdout.components(separatedBy: .newlines).first,
 			!path.isEmpty
@@ -21,92 +15,102 @@ public final class BadondefileRunner {
 		}
 		return path
 	}
+}
 
-	public func run(
-		with payload: Payload,
-		logCapture: ((Log) -> Void)? = nil,
-		stderrCapture: ((String) -> Void)? = nil
-	) throws -> Output {
-		let payloadData = try JSONEncoder().encode(payload)
-		try payloadData.write(to: URL(fileURLWithPath: Payload.path(forRepositoryPath: repositoryPath)))
+extension Badondefile {
+	public final class Runner {
+		let repositoryPath: String
 
-		try run(
-			stdoutCapture: { line in
-				line.components(losslesslySeparatedBy: CharacterSet(charactersIn: Log.Symbol.all.joined()))
-					.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-					.compactMap { Log(rawValue: $0) }
-					.forEach { logCapture?($0) }
-			},
-			stderrCapture: { line in
-				stderrCapture?(line)
+		public init(forRepositoryPath path: String) {
+			self.repositoryPath = path
+		}
+
+		public func run(
+			with payload: Payload,
+			logCapture: ((Log) -> Void)? = nil,
+			stderrCapture: ((String) -> Void)? = nil
+		) throws -> Output {
+			let payloadData = try JSONEncoder().encode(payload)
+			try payloadData.write(to: URL(fileURLWithPath: Payload.path(forRepositoryPath: repositoryPath)))
+
+			try run(
+				stdoutCapture: { line in
+					line.components(losslesslySeparatedBy: CharacterSet(charactersIn: Log.Symbol.all.joined()))
+						.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+						.compactMap { Log(rawValue: $0) }
+						.forEach { logCapture?($0) }
+				},
+				stderrCapture: { line in
+					stderrCapture?(line)
+				}
+			)
+
+			let outputData = try Data(contentsOf: URL(fileURLWithPath: Output.path(forRepositoryPath: repositoryPath)))
+			let output = try JSONDecoder().decode(Output.self, from: outputData)
+			return output
+		}
+
+		private func run(stdoutCapture: @escaping (String) -> Void, stderrCapture: @escaping (String) -> Void) throws {
+			let output = PipeStream()
+			let error = PipeStream()
+			let bash = try [
+				"swift",
+				bashLibraryPathArgument("-L"),
+				bashLibraryPathArgument("-I"),
+				"-lBadondeKit",
+				bashBadondefilePath(),
+				bashPayloadPath(),
+			].joined(separator: " ")
+			let task = Task(executable: "/bin/bash", arguments: ["-c", bash], stdout: output, stderr: error)
+
+			output.readHandle.readabilityHandler = { handle in
+				guard
+					let string = String(data: handle.availableData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+					!string.isEmpty
+				else {
+					return
+				}
+				stdoutCapture(string)
 			}
-		)
 
-		let outputData = try Data(contentsOf: URL(fileURLWithPath: Output.path(forRepositoryPath: repositoryPath)))
-		let output = try JSONDecoder().decode(Output.self, from: outputData)
-		return output
-	}
+			let exitStatus = task.runSync()
 
-	private func run(stdoutCapture: @escaping (String) -> Void, stderrCapture: @escaping (String) -> Void) throws {
-		let output = PipeStream()
-		let error = PipeStream()
-		let bash = try [
-			"swift",
-			bashLibraryPathArgument("-L"),
-			bashLibraryPathArgument("-I"),
-			"-lBadondeKit",
-			bashBadondefilePath(),
-			bashPayloadPath(),
-		].joined(separator: " ")
-		let task = Task(executable: "/bin/bash", arguments: ["-c", bash], stdout: output, stderr: error)
-
-		output.readHandle.readabilityHandler = { handle in
-			guard
-				let string = String(data: handle.availableData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-				!string.isEmpty
-			else {
-				return
+			let stderrContent = error.readAll().trimmingCharacters(in: .whitespacesAndNewlines)
+			if !stderrContent.isEmpty {
+				stderrCapture(stderrContent)
 			}
-			stdoutCapture(string)
+
+			if exitStatus != EXIT_SUCCESS {
+				exit(exitStatus)
+			}
 		}
 
-		let exitStatus = task.runSync()
-
-		let stderrContent = error.readAll().trimmingCharacters(in: .whitespacesAndNewlines)
-		if !stderrContent.isEmpty {
-			stderrCapture(stderrContent)
+		private func bashLibraryPathArgument(_ name: String) -> String {
+			return [name, bashLibrariesPath].joined(separator: " ")
 		}
 
-		if exitStatus != EXIT_SUCCESS {
-			exit(exitStatus)
+		private lazy var bashLibrariesPath: String = {
+			let path: String
+			#if DEBUG
+			path = URL(fileURLWithPath: CommandLine.arguments[0]).deletingLastPathComponent().path
+			#else
+			path = "/usr/local/lib/badonde"
+			#endif
+			return "'\(path)'"
+		}()
+
+		private func bashBadondefilePath() throws -> String {
+			return try "'\(Badondefile.path(forRepositoryPath: repositoryPath))'"
 		}
-	}
 
-	private func bashLibraryPathArgument(_ name: String) -> String {
-		return [name, bashLibrariesPath].joined(separator: " ")
-	}
-
-	private lazy var bashLibrariesPath: String = {
-		let path: String
-		#if DEBUG
-		path = URL(fileURLWithPath: CommandLine.arguments[0]).deletingLastPathComponent().path
-		#else
-		path = "/usr/local/lib/badonde"
-		#endif
-		return "'\(path)'"
-	}()
-
-	private func bashBadondefilePath() throws -> String {
-		return try "'\(badondefilePath())'"
-	}
-
-	private func bashPayloadPath() -> String {
-		let path = Payload.path(forRepositoryPath: repositoryPath)
-		return "'\(path)'"
+		private func bashPayloadPath() -> String {
+			let path = Payload.path(forRepositoryPath: repositoryPath)
+			return "'\(path)'"
+		}
 	}
 }
 
-extension BadondefileRunner {
+extension Badondefile {
 	public enum Error: LocalizedError {
 		case badondefileNotFound
 


### PR DESCRIPTION
## Description

Implement `badonde edit` command to edit `Badondefile.swift` with enabled autocompletion.

## Rationale

- Editing `Badondefile.swift` just by opening it with Xcode is cumbersome because no symbols from `BadondeKit` or even `Foundation` are recognized by the IDE, which makes the experience hard and unpleasing.

## Implementation

Still unclear, but most likely adopting a mechanism like [danger-swift](https://github.com/danger/swift)'s `edit` command or a simplified version without using Marathon.