### PR TITLE
Calling `badonde config` exits with error

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/DavdRoman/SwiftCLI",
         "state": {
           "branch": "master",
-          "revision": "491ed6ce33e8c690185c23896540021ecae11c65",
+          "revision": "9cde98d69c8ad333b6629e1651aabb545a8dea05",
           "version": null
         }
       },


### PR DESCRIPTION
A bug in SwiftCLI makes invocation of a parameterless command with required parameters throw an invisible error to side-effectly print the help message of such command. This translates to Badonde triggering error analytics when this happens. This should be fixed by addressing this SwiftCLI's hack.