### PR TITLE
Pivotal Tracker support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,7 +29,6 @@ opt_in_rules:
   - yoda_condition
   - unavailable_function
   - type_contents_order
-  - strict_fileprivate
   - static_operator
   - single_test_class
   - redundant_type_annotation

--- a/Sources/BadondeKit/Badonde.swift
+++ b/Sources/BadondeKit/Badonde.swift
@@ -160,10 +160,10 @@ public final class Badonde {
 		self.github = githubDSL
 
 		switch ticketInfo {
-		case .github?, .none:
-			break
 		case .jira(let ticket)?:
 			self.jira = JiraDSL(ticket: ticket)
+		case .github?, .none:
+			break
 		}
 
 		badonde = self

--- a/Sources/BadondeKit/Strategies.swift
+++ b/Sources/BadondeKit/Strategies.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Git
+import GitHub
+import Jira
+
+extension Badonde {
+	/// Defines a type of issue and how it's derived.
+	public enum TicketType {
+		/// Defines the way in which to derive a Jira ticket ID through the current Git
+		/// context.
+		public enum JiraDerivationStrategy {
+			enum Constant {
+				static let regex = #"((?<!([A-Z]{1,10})-?)[A-Z]+-\d+)"#
+			}
+
+			/// Use the official Jira regular expression to match a ticket ID:
+			/// `((?<!([A-Z]{1,10})-?)[A-Z]+-\d+)`
+			case regex
+			/// Use a user-provided custom function with the currently checked out branch
+			/// name as a parameter to derive the ticket ID.
+			///
+			/// If `nil` is returned, the property `Badonde.jira` becomes `nil`.
+			case custom((String) -> String?)
+
+			func ticketKey(forCurrentBranch currentBranch: Branch) throws -> Ticket.Key? {
+				switch self {
+				case .regex:
+					guard
+						let rawTicketKey = currentBranch.name.firstMatch(forRegex: Constant.regex, options: .caseInsensitive),
+						let ticketKey = Ticket.Key(rawValue: rawTicketKey.uppercased())
+					else {
+						return nil
+					}
+					return ticketKey
+				case .custom(let strategyClosure):
+					guard let rawTicketKey = strategyClosure(currentBranch.name) else {
+						return nil
+					}
+					guard let ticketKey = Ticket.Key(rawValue: rawTicketKey) else {
+						throw Error.invalidTicketNumberByCustomStrategy
+					}
+					return ticketKey
+				}
+			}
+		}
+
+		/// Defines the way in which to derive a GitHub Issue number through the current Git
+		/// context.
+		public enum GitHubIssueDerivationStrategy {
+			enum Constant {
+				static let regex = #"\d+"#
+			}
+
+			/// Match the first occurrence of a number in the current branch with regex
+			/// `\d+`
+			case regex
+			/// Use a user-provided custom function with the currently checked out branch
+			/// name as a parameter to derive the issue number.
+			///
+			/// If `nil` is returned, the property `Badonde.githubDSL.issue` becomes `nil`.
+			case custom((String) -> String?)
+
+			func issueNumber(forCurrentBranch currentBranch: Branch) throws -> String? {
+				switch self {
+				case .regex:
+					return currentBranch.name.firstMatch(forRegex: Constant.regex, options: .caseInsensitive)
+				case .custom(let strategyClosure):
+					return strategyClosure(currentBranch.name)
+				}
+			}
+		}
+
+		/// A JIRA Issue.
+		case jira(organization: String, derivationStrategy: JiraDerivationStrategy)
+		/// A GitHub Issue.
+		case githubIssue(derivationStrategy: GitHubIssueDerivationStrategy)
+	}
+}
+
+extension Badonde.TicketType.JiraDerivationStrategy {
+	enum Error: LocalizedError {
+		case invalidTicketNumberByCustomStrategy
+
+		var errorDescription: String? {
+			switch self {
+			case .invalidTicketNumberByCustomStrategy:
+				return "The ticket number derived by custom strategy has invalid format"
+			}
+		}
+	}
+}
+
+extension Badonde {
+	/// Defines the way in which to derive the Git base branch of the PR through the
+	/// current Git context.
+	public enum BaseBranchDerivationStrategy {
+		/// Use the configured default branch for the repo (`git.defaultBranch`).
+		case defaultBranch
+		/// Use the specified branch by name.
+		case branch(named: String)
+		/// Use a derivation algorithm that compares how many commits away the current
+		/// branch is from all other branches, and selects the one with the smallest
+		/// non-zero amount.
+		case commitProximity
+		/// Use a user-provided custom function with the currently checked out branch
+		/// name as a parameter to derive the base branch.
+		case custom((String) -> String)
+
+		func baseBranch(forDefaultBranch defaultBranch: Branch, remote: Remote, currentBranch: Branch, repositoryPath: String) throws -> Branch {
+			switch self {
+			case .defaultBranch:
+				return defaultBranch
+			case .branch(let name):
+				return try Branch(name: name, source: .remote(remote))
+			case .commitProximity:
+				return try currentBranch.parent(for: remote, defaultBranch: defaultBranch, atPath: repositoryPath)
+			case .custom(let strategyClosure):
+				return try Branch(name: strategyClosure(currentBranch.name), source: .local)
+			}
+		}
+	}
+}

--- a/Sources/CLI/Initializer.swift
+++ b/Sources/CLI/Initializer.swift
@@ -26,8 +26,11 @@ extension FileManager: FileInteractor {
 final class Initializer {
 	struct Credentials {
 		var githubAccessToken: String
-		var jiraEmail: String?
-		var jiraApiToken: String?
+		var ticketServiceCredentials: TicketServiceCredentials?
+
+		enum TicketServiceCredentials {
+			case jira(email: String, apiToken: String)
+		}
 	}
 
 	private let fileInteractor: FileInteractor
@@ -58,9 +61,13 @@ final class Initializer {
 
 	private func saveCredentials(_ credentials: Credentials, to configuration: KeyValueInteractive) throws {
 		try configuration.setRawValue(credentials.githubAccessToken, forKeyPath: .githubAccessToken)
-		if let jiraEmail = credentials.jiraEmail, let jiraApiToken = credentials.jiraApiToken {
-			try configuration.setRawValue(jiraEmail, forKeyPath: .jiraEmail)
-			try configuration.setRawValue(jiraApiToken, forKeyPath: .jiraApiToken)
+
+		switch credentials.ticketServiceCredentials {
+		case let .jira(email, apiToken)?:
+			try configuration.setRawValue(email, forKeyPath: .jiraEmail)
+			try configuration.setRawValue(apiToken, forKeyPath: .jiraApiToken)
+		case .none:
+			break
 		}
 	}
 

--- a/Sources/CLI/Prompter.swift
+++ b/Sources/CLI/Prompter.swift
@@ -50,7 +50,7 @@ enum Prompter {
 	static func promptTicketService() -> TicketService {
 		let serviceNumber = Input.readInt(
 			prompt: TicketService.promptDescription,
-			validation: [.custom("Invalid number", { TicketService(rawValue: $0) != nil })]
+			validation: [.custom("input a valid number from the list", { TicketService(rawValue: $0 - 1) != nil })]
 		)
 		guard let service = TicketService(rawValue: serviceNumber - 1) else {
 			fatalError("Prompt validation failed")

--- a/Sources/CLI/Prompter.swift
+++ b/Sources/CLI/Prompter.swift
@@ -18,10 +18,44 @@ private extension URL {
 }
 
 enum Prompter {
+	enum TicketService: Int, CaseIterable {
+		case jira
+		case githubIssues
+		case none
+
+		fileprivate var name: String {
+			switch self {
+			case .jira:
+				return "Jira"
+			case .githubIssues:
+				return "GitHub Issues"
+			case .none:
+				return "None"
+			}
+		}
+
+		fileprivate static var promptDescription: String {
+			let heading = "Select your issue tracking software:"
+			let list = allCases.map { "  \($0.rawValue + 1). \($0.name)" }.joined(separator: "\n")
+			return [heading, list].joined(separator: "\n") + "\n"
+		}
+	}
+
 	enum Subject {
 		case githubAccessToken
 		case jiraEmail
 		case jiraApiToken
+	}
+
+	static func promptTicketService() -> TicketService {
+		let serviceNumber = Input.readInt(
+			prompt: TicketService.promptDescription,
+			validation: [.custom("Invalid number", { TicketService(rawValue: $0) != nil })]
+		)
+		guard let service = TicketService(rawValue: serviceNumber - 1) else {
+			fatalError("Prompt validation failed")
+		}
+		return service
 	}
 
 	static func prompt(_ subject: Subject) throws -> String {
@@ -40,7 +74,7 @@ enum Prompter {
 
 			return authorization.token
 		case .jiraEmail:
-			return Input.readLine(prompt: "Enter JIRA email address (skip if blank):")
+			return Input.readLine(prompt: "Enter JIRA email address:")
 		case .jiraApiToken:
 			#if !DEBUG
 			open(.jiraApiTokenUrl, delay: URL.jiraApiTokenUrlOpeningDelay)


### PR DESCRIPTION
## Description

Add support for fetching Pivotal Tracker tickets.

## Rationale

- Pivotal Tracker is a widely used tool.
- Limiting task sources to just JIRA and GitHub can only take this tool so far. Providing more options would broaden the userbase.

## Implementation

- [x] Ticket Management Service selector on `badonde init`.
- [ ] `PivotalTracker` module.
- [ ] `BadondeKit.PivotalTrackerDSL`.

Ref:

- Authentication: https://www.pivotaltracker.com/help/api#Authenticating_Using_API_Tokens

<h6 align="right">
<img width="12" height="12" src="https://imgur.com/download/Zz8GL0X">
Generated by <a href="https://badonde.dev">Badonde</a>
</h6>